### PR TITLE
Point to maintained C:AMIE branch of Analog

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,7 +401,7 @@ Comparison of NoSQL servers: http://kkovacs.eu/cassandra-vs-mongodb-vs-couchdb-v
 ## Statistics
 *Analytics software.*
 
-* [Analog](http://www.web42.com/analog/) - The most popular logfile analyser in the world.
+* [Analog C:AMIE](http://www.c-amie.co.uk/analog/) - The most popular logfile analyser in the world (C: AMIE Maintenance Branch).
 * [GoAccess](http://goaccess.io/) - Open source real-time web log analyzer and interactive viewer that runs in a terminal.
 * [Piwik](http://piwik.org/) - Free and open source web analytics application.
 * [Webalizer](http://www.webalizer.org/) - Fast, free web server log file analysis program.


### PR DESCRIPTION
The "official" version of Analog (in the previous link) hasn't been updated since 2004.  The C:AMIE branch has maintenance updates to Analog 6.0 bringing support for log files from modern systems.
