### PR TITLE
Add link to Bareos (Bacula fork)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ A curated list of amazingly awesome open source sysadmin resources inspired by [
 * [Backupninja](https://labs.riseup.net/code/projects/backupninja) - Lightweight, extensible meta-backup system.
 * [Backuppc](http://backuppc.sourceforge.net/) - Client-server model backup tool with file pooling scheme.
 * [Bup](https://github.com/bup/bup) - Incremental backups with rolling checksums, git packfiles, de-duplication, and a FUSE filesystem.
+* [Bareos](http://www.bareos.org) - Bacula fork focused on modularity & community engagement.
 * [Burp](http://burp.grke.org/) - Network backup and restore program.
 * [Duplicity](http://duplicity.nongnu.org/) - Encrypted bandwidth-efficient backup using the rsync algorithm.
 * [FreeFileSync](http://www.freefilesync.org) - Folder comparison and synchronization tool.


### PR DESCRIPTION
Bareos and Bacula are both being maintained, and have diverged significantly.  Bareos has added support for VMWare backups, cloud storage environments, python plugins, running the storage daemon on Windows, backups to ceph & gluster, web UI, etc.  (Bacula has implemented some of these in their commerical product and will likely implement some in the FOSS edition as well.  I don't think Bacula should be removed from this list by ANY means - it's still a _fantastic_ backup solution).
