### PR TITLE
Moved syncing tools to cloud storage from backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,6 @@ A curated list of amazingly awesome open source sysadmin resources inspired by [
 * [Bup](https://github.com/bup/bup) - Incremental backups with rolling checksums, git packfiles, de-duplication, and a FUSE filesystem.
 * [Burp](http://burp.grke.org/) - Network backup and restore program.
 * [Duplicity](http://duplicity.nongnu.org/) - Encrypted bandwidth-efficient backup using the rsync algorithm.
-* [FreeFileSync](http://www.freefilesync.org) - Folder comparison and synchronization tool.
-* [Lsyncd](https://github.com/axkibe/lsyncd) - Watches a local directory trees for changes, and then spawns a process to synchronize the changes. Uses rsync by default.
 * [Rsnapshot](http://www.rsnapshot.org/) - Filesystem Snapshotting Utility.
 * [SafeKeep](http://safekeep.sourceforge.net/) - Centralized pull-based backup using `rdiff-backup`.
 * [TarSnap](https://www.tarsnap.com/) - Secure backup service with an open-source client.
@@ -110,7 +108,9 @@ A curated list of amazingly awesome open source sysadmin resources inspired by [
 
 ## Cloud Storage
 
+* [FreeFileSync](http://www.freefilesync.org) - Folder comparison and synchronization tool.
 * [git-annex assistant](http://git-annex.branchable.com/assistant/) - A synchronised folder on each of your OSX and Linux computers, Android devices, removable drives, NAS appliances, and cloud services.
+* [Lsyncd](https://github.com/axkibe/lsyncd) - Watches a local directory trees for changes, and then spawns a process to synchronize the changes. Uses rsync by default.
 * [ownCloud](https://owncloud.org) - Provides universal access to your files via the web, your computer or your mobile devices.
 * [Seafile](http://seafile.com) - Another Open Source Cloud Storage solution.
 * [SparkleShare](http://sparkleshare.org/) - Provides cloud storage and file synchronization services. By default, it uses Git as a storage backend.


### PR DESCRIPTION
lsyncd and FreeFileSync are both sync tools moreso than backup; I've moved them alongside Syncthing, which is nearly identical. (That said, these should probably be in a separate category with a few other sync tools).
